### PR TITLE
Cachebust

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "metalsmith-markdown": "~0.2.1",
     "metalsmith-permalinks": "~0.4.0",
     "metalsmith-sass": "~0.7.0",
-    "metalsmith-swig-helpers": "^1.0.0",
+    "metalsmith-swig-helpers": "^1.1.1",
     "metalsmith-templates": "~0.6.0",
     "metalsmith-templates": "~0.6.0",
     "metalsmith-metadata": "~0.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "metalsmith-markdown": "~0.2.1",
     "metalsmith-permalinks": "~0.4.0",
     "metalsmith-sass": "~0.7.0",
-    "metalsmith-swig-helpers": "^1.1.1",
+    "metalsmith-swig-helpers": "^1.1.2",
     "metalsmith-templates": "~0.6.0",
     "metalsmith-templates": "~0.6.0",
     "metalsmith-metadata": "~0.0.1",

--- a/templates/html.html
+++ b/templates/html.html
@@ -22,7 +22,7 @@
   {% endblock %}
 
   {% block styles %}
-  <link rel="stylesheet" type="text/css" href="/styles/main.css">
+  <link rel="stylesheet" type="text/css" href="{{'/styles/main.css'|bustcache}}">
   {% endblock %}
 
 </head>
@@ -65,7 +65,7 @@
     <script src="/vendor/matchHeight/jquery.matchHeight.js"></script>
     <script src="/vendor/holderjs/holder.js"></script>
     <script src="/vendor/bootstrap-sass-twbs/assets/javascripts/bootstrap.js"></script>
-    <script src="/js/scripts.js"></script>
+    <script src="{{'/js/scripts.js'|bustcache}}"></script>
   {% endblock %}
 
 </body>


### PR DESCRIPTION
Satisfies #108 

usage:
```
{{'/path/to/your/asset.ext'|bustcache}}
```
this appends the output of ``Date.now()``` (ms since the unix epoch) at time of generation to the query string for that asset.

eg. 
```<script src="/js/scripts.js?1430256127758"></script>```
