### PR TITLE
Fix Source Sans Pro

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
     "fontawesome": "~4.2.0",
     "holderjs": "~2.4.0",
     "matchHeight": "~0.5.2",
-    "xor-crypt": "~0.0.2"
+    "xor-crypt": "~0.0.2",
+    "fontface-source-sans-pro": "*"
   }
 }

--- a/metalsmith.json
+++ b/metalsmith.json
@@ -34,7 +34,9 @@
       "dest": "."
     },
     "metalsmith-sass": {
-      "outputStyle": "expanded",
+      "outputStyle": "nested",
+      "sourceComments": true,
+      "sourceMap": true,
       "includePaths": [
         "assets/vendor",
         "assets/vendor/bootstrap-sass-twbs/assets/stylesheets",

--- a/src/styles/_fontawesome.scss
+++ b/src/styles/_fontawesome.scss
@@ -768,7 +768,7 @@ Styleguide 6.0
 */
 
 // Customized Variables - Overrides the !defaults.
-$fa-font-path: "../vendor/fontawesome/fonts";
+$fa-font-path: "/vendor/fontawesome/fonts";
 
 // Vendor Code
 @import "font-awesome";

--- a/src/styles/base/_bsvars.scss
+++ b/src/styles/base/_bsvars.scss
@@ -3,7 +3,7 @@
 $body-bg: #f3f3f3;
 $gray-dark: #444;
 
-$font-family-sans-serif:  "SourceSansPro", Helvetica, Arial, sans-serif;
+$font-family-sans-serif:  "Source Sans Pro", Helvetica, Arial, sans-serif;
 $font-family-serif:       Georgia, "Times New Roman", Times, serif !default;
 //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
 $font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace !default;

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -31,10 +31,9 @@ cillum dolore eu fugiat nulla pariatur.</blockquote>
 Styleguide 4.1
 */
 
-@include font-face("SourceSansPro", "/fonts/sourcesanspro-regular" );
-@include font-face("SourceSansPro", "/fonts/sourcesanspro-italic", normal, italic);
-@include font-face("SourceSansPro", "/fonts/sourcesanspro-bold", bold );
-@include font-face("SourceSansPro", "/fonts/sourcesanspro-bolditalic", bold, italic);
+// Source Sans Pro Vendor
+$SourceSansProFontsPath: "/vendor/fontface-source-sans-pro/fonts";
+@import "fontface-source-sans-pro/scss/source-sans-pro";
 
 textarea,
 input {


### PR DESCRIPTION
The font was missing. We can use Bower to bring it in, and SASS to fix the relative path.