### PR TITLE
 #187: Reduce Travis build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - '0.10'
+sudo: false
 after_success:
 # Automatically accept the host key authentication
 - echo -e "Host *\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config


### PR DESCRIPTION
This allows use of the Docker-based Travis build system. Speeds up Travis build time quite a bit.

Somewhat related, but not really: https://github.com/kalamuna/kalastatic/issues/187