### PR TITLE
KSTAT-74 Add documentation about versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,11 @@ Deploy the site by running:
 2. Visit [`0.0.0.0:8000`](http://0.0.0.0:8000) in your browser
 3. Visit [`0.0.0.0:8000/stylguide`](http://0.0.0.0:8000/styleguide) for the style guide
 4. Visit [`0.0.0.0:8000/a11y`](http://0.0.0.0:8000/a11y) for an accessibility report
+
+### Releases
+
+In order for a release to be made, the following workflows must be met:
+
+1. All merged Pull Requests to `master` are automatically pushed up to the [DEV environment on Pantheon](https://dashboard.pantheon.io/sites/99097056-c6bd-451e-a94b-fc8f7666fbe5#dev/code)
+2. Periodically, we will push DEV up to TEST, to ensure all functionality is there.
+3. When TEST passes QA, we will tag a KalaStatic release using [Semantic Versioning](http://semver.org/).


### PR DESCRIPTION
Since we are using [Semantic Versioining](http://semver.org/), we can remove SPRINT. DEV becomes our integration/sprint branch. This adds documentation about that and how releases are made.