### PR TITLE
KSTAT-269: Add documentation about basePath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ notifications:
   email: false
 env:
   global:
+  # basePath - Defines what KalaStatic considers the webroot. Change this
+  # if you would like the KalaStatic build to live in a sub-folder.
+  # Defaults to "/".
+  #- basePath: /sites/all/themes/mytheme/kalastatic/build/
   - GIT_NAME: Kala C. Bot
   - GIT_EMAIL: kalacommitbot@kalamuna.com
   - GH_REPO: kalamuna/kalastatic

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ You can change the webroot path of the static site by manipulating the `basePath
 basePath=/sites/all/themes/mytheme/kalastatic/build/ npm test
 ```
 
-From within the template, use the `basePath` variable when you want to link to a file from the webroot"
+From within the template, use the `basePath` variable when you want to link to a file from the webroot.
 
 ```
 <link rel="stylesheet" type="text/css" href="{{basePath}}styles/main.css'">
 ```
 
-The default of `basePath` is `/`.
+The default of `basePath` is `/`. This can also be set in [`.travis.yml`](.travis.yml).
 
 ### Deployment
 


### PR DESCRIPTION
Fixes up the documentation for [using basePath](https://github.com/kalamuna/kalastatic/issues/269).

## QA
- [Developer docs](https://github.com/kalamuna/kalastatic#basepath)
- [Wiki](https://github.com/kalamuna/kalastatic/wiki/Building-for-Drupal-Integration)
- [Check the new docs at https://github.com/kalamuna/kalastatic/pull/274/files](https://github.com/kalamuna/kalastatic/pull/274/files)

ADD ALL THE DOCS! Thanks Trooooooth.