### PR TITLE
KSTAT-296 Fix for latest node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "metalsmith-move-up": "^1.0.0",
     "metalsmith-permalinks": "~0.4.0",
     "metalsmith-sass": "^1.3.0",
-    "node-sass": "3.4.2",
     "metalsmith-swig-helpers": "^1.3.0",
     "metalsmith-tags": "^0.11.0",
     "metalsmith-templates": "~0.7.0",

--- a/src/components/molecules/lede/_lede.scss
+++ b/src/components/molecules/lede/_lede.scss
@@ -5,7 +5,7 @@
 }
 
 .lede {
-  @extend .jumboTron;
+  @extend .jumbotron;
   background: $body-bg;
   padding: 2em;
   margin-bottom: 2em;

--- a/src/components/organisms/footer/_footer.scss
+++ b/src/components/organisms/footer/_footer.scss
@@ -83,7 +83,7 @@ body {
 
   transition-property: width, height, margin-top;
   transition-duration: .25s;
-  @extend %easeOutOver;
+  @extend %easeOutQuad;
   margin-top: 0.0925em;
   width: 140px;
   height: 54px;

--- a/src/components/organisms/nav_fixed_top/_nav_fixed_top.scss
+++ b/src/components/organisms/nav_fixed_top/_nav_fixed_top.scss
@@ -15,7 +15,7 @@
 
   transition-property: width, height, margin-top;
   transition-duration: .25s;
-  @extend %easeOutOver;
+  @extend %easeOutQuad;
   margin-top: 0.065em;
   width: 231px;
   height: 89px;
@@ -51,7 +51,7 @@ $nav-bar-padding-shrunk: 1.5em;
 
         transition-property: padding-top, padding-bottom, font-size;
         transition-duration: .25s;
-        @extend %easeOutOver;
+        @extend %easeOutQuad;
 
         padding-top: $nav-bar-padding;
 
@@ -95,7 +95,7 @@ $nav-bar-padding-shrunk: 1.5em;
   @media screen and (min-width: $screen-sm) {
     transition-property: padding-top;
     transition-duration: .25s;
-    @extend %easeOutOver;
+    @extend %easeOutQuad;
 
     .shrunk & {
       padding-top: $nav-bar-padding-shrunk - $search-form-padding-offset;

--- a/src/components/organisms/nav_kalastatic/_nav_kalastatic.scss
+++ b/src/components/organisms/nav_kalastatic/_nav_kalastatic.scss
@@ -55,7 +55,7 @@ $nav-bar-padding-shrunk: 1.5em;
 
         transition-property: padding-top, padding-bottom, font-size;
         transition-duration: .25s;
-        @extend %easeOutOver;
+        /*@extend %easeOutQuad;*/
 
         padding-top: $nav-bar-padding;
 
@@ -99,7 +99,7 @@ $nav-bar-padding-shrunk: 1.5em;
   @media screen and (min-width: $screen-sm) {
     transition-property: padding-top;
     transition-duration: .25s;
-    @extend %easeOutOver;
+    /*@extend %easeOutQuad;*/
 
     .shrunk & {
       padding-top: $nav-bar-padding-shrunk - $search-form-padding-offset;

--- a/src/styles/base/_extendables.scss
+++ b/src/styles/base/_extendables.scss
@@ -54,3 +54,98 @@
 }
 
 
+
+// Transitions
+////////////////////////////////////
+
+// Cubic
+%easeInCubic {
+  transition-timing-function: cubic-bezier(0.550, 0.055, 0.675, 0.190);
+}
+
+%easeOutCubic {
+  transition-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+}
+
+%easeInOutCubic {
+  transition-timing-function: cubic-bezier(0.645, 0.045, 0.355, 1.000);
+}
+
+// Circ
+%easeInCirc {
+  transition-timing-function: cubic-bezier(0.600, 0.040, 0.980, 0.335);
+}
+%easeOutCirc {
+  transition-timing-function: cubic-bezier(0.075, 0.820, 0.165, 1.000);
+}
+%easeInOutCirc {
+  transition-timing-function: cubic-bezier(0.785, 0.135, 0.150, 0.860);
+}
+
+// Expo
+%easeInExpo {
+  transition-timing-function: cubic-bezier(0.950, 0.050, 0.795, 0.035);
+}
+%easeOutExpo {
+  transition-timing-function: cubic-bezier(0.190, 1.000, 0.220, 1.000);
+}
+%easeInOutExpo {
+  transition-timing-function: cubic-bezier(1.000, 0.000, 0.000, 1.000);
+}
+
+// Quad
+%easeInQuad {
+  transition-timing-function: cubic-bezier(0.550, 0.085, 0.680, 0.530);
+}
+%easeOutQuad {
+  transition-timing-function: cubic-bezier(0.250, 0.460, 0.450, 0.940);
+}
+%easeInOutQuad {
+  transition-timing-function: cubic-bezier(0.455, 0.030, 0.515, 0.955);
+}
+
+// Quart
+%easeInQuart {
+  transition-timing-function: cubic-bezier(0.895, 0.030, 0.685, 0.220);
+}
+%easeOutQuart {
+  transition-timing-function: cubic-bezier(0.165, 0.840, 0.440, 1.000);
+}
+%easeInOutQuart {
+  transition-timing-function: cubic-bezier(0.770, 0.000, 0.175, 1.000);
+}
+
+// Quint
+%easeInQuint {
+  transition-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
+}
+%easeOutQuint {
+  transition-timing-function: cubic-bezier(0.230, 1.000, 0.320, 1.000);
+}
+%easeInOutQuint {
+  transition-timing-function: cubic-bezier(0.860, 0.000, 0.070, 1.000);
+}
+
+// Sine
+%easeInSine {
+  transition-timing-function: cubic-bezier(0.470, 0.000, 0.745, 0.715);
+}
+%easeOutSine {
+  transition-timing-function: cubic-bezier(0.390, 0.575, 0.565, 1.000);
+}
+%easeInOutSine {
+  transition-timing-function: cubic-bezier(0.445, 0.050, 0.550, 0.950);
+}
+
+// Back
+%easeInBack {
+  transition-timing-function: cubic-bezier(0.600, -0.280, 0.735, 0.045);
+}
+
+%easeOutBack {
+  transition-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.275);
+}
+
+%easeInOutBack {
+  transition-timing-function: cubic-bezier(0.680, -0.550, 0.265, 1.550);
+}


### PR DESCRIPTION
RE: #296 

This updates to the latest node-sass and makes the SASS build again. Josh mentioned that extending from a media query doesn't really do anything (fail silently). Latest node-sass now errors out when you attempt to do it.

@madeofpeople You were right, kalastatic was just missing the extendables from https://github.com/kalamuna/sass-boilerplate .