### PR TITLE
metalsmith swig helpes was missing from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "metalsmith-move-up": "^1.0.0",
     "metalsmith-permalinks": "~0.4.0",
     "metalsmith-sass": "^1.3.0",
-    "metalsmith-swig-helpers": "^1.3.0",
+    "metalsmith-swig-helpers": "^1.4.2",
     "metalsmith-tags": "^0.11.0",
     "metalsmith-templates": "~0.7.0",
     "swig": "^1.4.2",


### PR DESCRIPTION
@soniktrooth 
Not sure why, but the older version of metalsmith swig helpers seems to be breaking the build in master.

```
> kalastatic@0.6.2 build /Users/thiago/repos/kalastatic
> metalsmith build

>> 
>> Metalsmith · failed to require plugin "metalsmith-swig-helpers".
>> 
```