### PR TITLE
Allow content to use the same Styleguide .json content

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "metalsmith-jstransformer": "^0.10.0",
     "metalsmith-jstransformer-partials": "^1.2.3",
     "metalsmith-metadata-convention": "^1.0.1",
+    "metalsmith-metadata-files": "^1.0.0",
     "metalsmith-paths": "^3.0.1",
     "nconf": "^0.8.4",
     "nconf-yaml": "^1.0.2"

--- a/src/kalastatic.js
+++ b/src/kalastatic.js
@@ -17,6 +17,8 @@ function KalaStatic(nconf) {
     plugins: [
       // Load information from the environment variables.
       'metalsmith-env',
+      // Add .json metadata to each file.
+      'metalsmith-metadata-files',
       // Add base, dir, ext, name, and href info to each file.
       'metalsmith-paths',
       // Load metadata info the metalsmith metadata object.
@@ -169,7 +171,7 @@ KalaStatic.prototype.build = function () {
       }
 
       // Now that it's complete, run KSS on it.
-      kss({
+      return kss({
         stdout: process.stdout,
         stderr: reject,
         argv: argv

--- a/test/fixtures/styles/expected/main.css
+++ b/test/fixtures/styles/expected/main.css
@@ -1307,7 +1307,7 @@ Displays a button on the page.
 {% partial('button', {title: 'Hello World!'}) %}
 ```
 
-Markup: button-example.twig
+Markup: button.twig
 
 Styleguide kalastatic.button
 */

--- a/test/fixtures/styles/src/index.twig
+++ b/test/fixtures/styles/src/index.twig
@@ -5,10 +5,10 @@ pageTitle: Hello World!
 
 <h2>{{ pageTitle }}</h2>
 
-{{ partial('button', {primary: true, title: 'Hello!' })|raw }}
+{{ partial('button', {primary: true, title: 'Hello!', active: false })|raw }}
 
 <h2>Using Include with namespace</h2>
-{% include "@kalastatic/partials/atoms/button.twig" with { title: 'Hello World!' } %}
+{% include "@kalastatic/partials/atoms/button.twig" with { title: 'Hello World!' } only %}
 
 <h2>Button Group</h2>
-{% include "@kalastatic/partials/molecules/button-group.twig" with { buttons: {one: {title: 'Button One'}, two: {title: 'Button Two'}} } %}
+{% include "@kalastatic/partials/molecules/button-group.twig" with { buttons: {one: {title: 'Button One'}, two: {title: 'Button Two'}} } only %}

--- a/test/fixtures/styles/src/partials/atoms/_button.scss
+++ b/test/fixtures/styles/src/partials/atoms/_button.scss
@@ -19,7 +19,7 @@ Displays a button on the page.
 {% partial('button', {title: 'Hello World!'}) %}
 ```
 
-Markup: button-example.twig
+Markup: button.twig
 
 Styleguide kalastatic.button
 */

--- a/test/fixtures/styles/src/partials/atoms/button-example.twig
+++ b/test/fixtures/styles/src/partials/atoms/button-example.twig
@@ -1,5 +1,0 @@
-{% include 'button.twig' with {
-  title: 'Hello World!',
-  active: true,
-  primary: true
-} %}

--- a/test/fixtures/styles/src/partials/atoms/button.json
+++ b/test/fixtures/styles/src/partials/atoms/button.json
@@ -1,0 +1,5 @@
+{
+  "title": "Hello World!",
+  "active": true,
+  "primary": true
+}

--- a/test/fixtures/twig-filters/expected/twig-test.html
+++ b/test/fixtures/twig-filters/expected/twig-test.html
@@ -1,3 +1,6 @@
+<h1>Hello World!</h1>
+<p>This is a metadata file that's injected into twig-test!</p>
+
 <div class="twig-test">
   Hello-World
 </div>

--- a/test/fixtures/twig-filters/src/twig-test.json
+++ b/test/fixtures/twig-filters/src/twig-test.json
@@ -1,0 +1,3 @@
+{
+  "description": "This is a metadata file that's injected into twig-test!"
+}

--- a/test/fixtures/twig-filters/src/twig-test.twig
+++ b/test/fixtures/twig-filters/src/twig-test.twig
@@ -1,6 +1,9 @@
 ---
 title: Hello World!
 ---
+<h1>{{ title }}</h1>
+<p>{{ description }}</p>
+
 <div class="twig-test">
   {{title|slugifythis}}
 </div>


### PR DESCRIPTION
This allows the Styleguide and Prototype to use the same mock data.

https://www.npmjs.com/package/metalsmith-metadata-files