### PR TITLE
@kalastatic »» @kstat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.1: 2017-01-12
 
-- The `metalsmith-metadata-files` inherited files key is now `@kalastatic/`
+- The `metalsmith-metadata-files` inherited files key is now `@kstat/`
 
 ## 3.0.0: 2017-01-10
 

--- a/src/kalastatic.js
+++ b/src/kalastatic.js
@@ -67,14 +67,14 @@ KalaStatic.prototype.build = function () {
         engineOptions: {
           twig: {
             namespaces: {
-              kalastatic: path.join(base, source)
+              kstat: path.join(base, source)
             }
           }
         }
       },
       'metalsmith-ignore': '**/_*',
       'metalsmith-metadata-files': {
-        inheritFilePrefix: '@kalastatic/'
+        inheritFilePrefix: '@kstat/'
       }
     }
     var pluginOpts = config.get('pluginOpts')
@@ -134,7 +134,7 @@ KalaStatic.prototype.build = function () {
           // Choose the Twig builder.
           '--builder=' + kssConf.builder,
           // Add the Twig Namespace.
-          '--namespace=kalastatic:' + path.join(base, source)
+          '--namespace=kstat:' + path.join(base, source)
         )
 
         // Add the optional configurations.

--- a/test/fixtures/styles/expected/styleguide/item-kalastatic-button-group.html
+++ b/test/fixtures/styles/expected/styleguide/item-kalastatic-button-group.html
@@ -126,7 +126,7 @@
   &lt;ul&gt;
     {% for button in buttons %}
       &lt;li&gt;
-        {% include &quot;@kalastatic/partials/atoms/button.twig&quot; with button only %}
+        {% include &quot;@kstat/partials/atoms/button.twig&quot; with button only %}
       &lt;/li&gt;
     {% endfor %}
   &lt;/ul&gt;

--- a/test/fixtures/styles/expected/styleguide/section-kalastatic.html
+++ b/test/fixtures/styles/expected/styleguide/section-kalastatic.html
@@ -316,7 +316,7 @@
   &lt;ul&gt;
     {% for button in buttons %}
       &lt;li&gt;
-        {% include &quot;@kalastatic/partials/atoms/button.twig&quot; with button only %}
+        {% include &quot;@kstat/partials/atoms/button.twig&quot; with button only %}
       &lt;/li&gt;
     {% endfor %}
   &lt;/ul&gt;

--- a/test/fixtures/styles/src/index.twig
+++ b/test/fixtures/styles/src/index.twig
@@ -8,7 +8,7 @@ pageTitle: Hello World!
 {{ partial('button', {primary: true, title: 'Hello!', active: false })|raw }}
 
 <h2>Using Include with namespace</h2>
-{% include "@kalastatic/partials/atoms/button.twig" with { title: 'Hello World!' } only %}
+{% include "@kstat/partials/atoms/button.twig" with { title: 'Hello World!' } only %}
 
 <h2>Button Group</h2>
-{% include "@kalastatic/partials/molecules/button-group.twig" with { buttons: {one: {title: 'Button One'}, two: {title: 'Button Two'}} } only %}
+{% include "@kstat/partials/molecules/button-group.twig" with { buttons: {one: {title: 'Button One'}, two: {title: 'Button Two'}} } only %}

--- a/test/fixtures/styles/src/partials/molecules/button-group.twig
+++ b/test/fixtures/styles/src/partials/molecules/button-group.twig
@@ -2,7 +2,7 @@
   <ul>
     {% for button in buttons %}
       <li>
-        {% include "@kalastatic/partials/atoms/button.twig" with button only %}
+        {% include "@kstat/partials/atoms/button.twig" with button only %}
       </li>
     {% endfor %}
   </ul>

--- a/test/fixtures/twig-filters/src/twig-test.json
+++ b/test/fixtures/twig-filters/src/twig-test.json
@@ -1,4 +1,4 @@
 {
   "description": "This is a metadata file that's injected into twig-test!",
-  "person": "@kalastatic/person.json"
+  "person": "@kstat/person.json"
 }


### PR DESCRIPTION
@soniktrooth passing tests.

Note that it assumes @kstat for both twig paths and also for the JSON key inclusion stuff (we should go full consistent anyway) and I like @kstat better anyway (my aching fingers!)