### PR TITLE
browsersync: Allow the file browser

### DIFF
--- a/bin/kalastatic
+++ b/bin/kalastatic
@@ -70,10 +70,21 @@ program
       var bs = browserSync.create('kalastatic')
 
       // Set up the server.
+      var serverConfig = {
+        // Configure the base directory.
+        baseDir: bsWebroot || finalDest
+      }
+      // Allow switching the BrowserSync index.
+      if (bsIndex) {
+        serverConfig.index = bsIndex
+      }
+      else {
+        // If no index is set, allow browsing by directories.
+        serverConfig.directory = true
+      }
       bs.init({
-        server: bsWebroot || finalDest,
-        browser: bsBrowser,
-        index: bsIndex
+        server: serverConfig,
+        browser: bsBrowser
       })
 
       // Create a watch task.


### PR DESCRIPTION
Using `directory: true` will allow browsing the files directory on the server when there is no index set.