### PR TITLE
Made cleanup of KS build to be configurable

### DIFF
--- a/src/kalastatic.js
+++ b/src/kalastatic.js
@@ -92,10 +92,12 @@ KalaStatic.prototype.build = function () {
       }
     }
 
+    const cleanBuild = config.get('cleanBuild') || false
+
     // Set up Metalsmith.
     metalsmith.source(source)
     metalsmith.destination(destination)
-    metalsmith.clean(config.get('cleanBuild'))
+    metalsmith.clean(cleanBuild)
 
     // Load the Metalsmith Plugins.
     for (const i in plugins) {

--- a/src/kalastatic.js
+++ b/src/kalastatic.js
@@ -95,6 +95,7 @@ KalaStatic.prototype.build = function () {
     // Set up Metalsmith.
     metalsmith.source(source)
     metalsmith.destination(destination)
+    metalsmith.clean(config.get('cleanBuild'))
 
     // Load the Metalsmith Plugins.
     for (const i in plugins) {


### PR DESCRIPTION
This would allow other developers to deactivate cleanup of destination folder before rebuilding, so it only overrides what has changed. This is needed if Kalastatic is being used alongside other tools that also need to generate assets inside the build folder, in this case you wouldn't want Metalsmith to delete these files.